### PR TITLE
feat: add extensions for `DateTime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,22 @@
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Chronology&metric=coverage)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Chronology)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Chronology%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Chronology/main)
 
-Extension methods for creating a `TimeSpan` that reads more natural.
+Extension methods for creating a `TimeSpan` or `DateTime` that reads more natural.
+
+
+## TimeSpan
+
+Add the following extension methods on `int` and `double` that allow creating a `TimeSpan`:
+- `.Milliseconds()`
+- `.Seconds()`
+- `.Minutes()`
+- `.Hours()`
+- `.Days()`
 
 ```csharp
 // ↓ Using traditional creation of TimeSpan
-await Expect.That(someAction).Should().ExecuteWithin(TimeSpan.FromSeconds(10));
-await Expect.That(someAction).Should().ExecuteWithin(10.Seconds());
+TimeSpan timeout = TimeSpan.FromSeconds(10);
+TimeSpan timeout = 10.Seconds();
 // ↑ Using the extension methods from this library
 ```
 
@@ -19,9 +29,24 @@ It is also possible to combine multiple extension methods:
 TimeSpan timeout = 1.Minutes(30.Seconds());
 ```
 
-Available methods are
-- `.Milliseconds()`
-- `.Seconds()`
-- `.Minutes()`
-- `.Hours()`
-- `.Days()`
+
+## DateTime
+
+Add extension methods on `int` for each month that allow creating a `DateTime`:
+
+```csharp
+// ↓ Using traditional creation of DateTime
+DateTime time = new DateTime(2024, 12, 24);
+DateTime time = 24.December(2024);
+// ↑ Using the extension methods from this library
+```
+
+It is also possible to specify a time:
+```csharp
+DateTime time = 24.December(2024).At(18, 30);
+```
+
+It is also possible combine this with the `TimeSpan` extensions:
+```csharp
+DateTime time = 3.Hours().Before(25.December(2024));
+```

--- a/Source/aweXpect.Chronology/DateTimeExtensions.cs
+++ b/Source/aweXpect.Chronology/DateTimeExtensions.cs
@@ -16,84 +16,84 @@ public static class DateTimeExtensions
 	///     in January of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime January(this int day, int year)
-		=> new(year, 1, day);
+		=> new(year, 1, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in February of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime February(this int day, int year)
-		=> new(year, 2, day);
+		=> new(year, 2, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in March of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime March(this int day, int year)
-		=> new(year, 3, day);
+		=> new(year, 3, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in April of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime April(this int day, int year)
-		=> new(year, 4, day);
+		=> new(year, 4, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in May of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime May(this int day, int year)
-		=> new(year, 5, day);
+		=> new(year, 5, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in June of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime June(this int day, int year)
-		=> new(year, 6, day);
+		=> new(year, 6, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in July of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime July(this int day, int year)
-		=> new(year, 7, day);
+		=> new(year, 7, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in August of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime August(this int day, int year)
-		=> new(year, 8, day);
+		=> new(year, 8, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in September of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime September(this int day, int year)
-		=> new(year, 9, day);
+		=> new(year, 9, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in October of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime October(this int day, int year)
-		=> new(year, 10, day);
+		=> new(year, 10, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in November of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime November(this int day, int year)
-		=> new(year, 11, day);
+		=> new(year, 11, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 	/// <summary>
 	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
 	///     in December of the given <paramref name="year" />.
 	/// </summary>
 	public static DateTime December(this int day, int year)
-		=> new(year, 12, day);
+		=> new(year, 12, day, 0, 0, 0, DateTimeKind.Unspecified);
 
 
 	/// <summary>

--- a/Source/aweXpect.Chronology/DateTimeExtensions.cs
+++ b/Source/aweXpect.Chronology/DateTimeExtensions.cs
@@ -1,0 +1,142 @@
+﻿using System;
+
+namespace aweXpect.Chronology;
+
+/// <summary>
+///     Extension methods for creating <see cref="DateTime" />.
+/// </summary>
+/// <example>
+///     Instead of <c>new DateTime(2024, 24, 12)</c><br />
+///     you can write <c>24.December(2024)</c>.
+/// </example>
+public static class DateTimeExtensions
+{
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in January of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime January(this int day, int year)
+		=> new(year, 1, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in February of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime February(this int day, int year)
+		=> new(year, 2, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in March of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime March(this int day, int year)
+		=> new(year, 3, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in April of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime April(this int day, int year)
+		=> new(year, 4, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in May of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime May(this int day, int year)
+		=> new(year, 5, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in June of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime June(this int day, int year)
+		=> new(year, 6, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in July of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime July(this int day, int year)
+		=> new(year, 7, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in August of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime August(this int day, int year)
+		=> new(year, 8, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in September of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime September(this int day, int year)
+		=> new(year, 9, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in October of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime October(this int day, int year)
+		=> new(year, 10, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in November of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime November(this int day, int year)
+		=> new(year, 11, day);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="day" />
+	///     in December of the given <paramref name="year" />.
+	/// </summary>
+	public static DateTime December(this int day, int year)
+		=> new(year, 12, day);
+
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="date" /> and <paramref name="time" />.
+	/// </summary>
+	public static DateTime At(this DateTime date, TimeSpan time)
+		=> date.Date + time;
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="date" /> and time
+	///     with the specified <paramref name="hours" />, <paramref name="minutes" />
+	///     and optionally <paramref name="seconds" /> and <paramref name="milliseconds" />.
+	/// </summary>
+	public static DateTime At(this DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0)
+		=> new(date.Year, date.Month, date.Day, hours, minutes, seconds, milliseconds, date.Kind);
+
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="dateTime" />
+	///     with kind set to <see cref="DateTimeKind.Utc" />.
+	/// </summary>
+	public static DateTime AsUtc(this DateTime dateTime)
+		=> DateTime.SpecifyKind(dateTime, DateTimeKind.Utc);
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> for the given <paramref name="dateTime" />
+	///     with kind set to <see cref="DateTimeKind.Local" />.
+	/// </summary>
+	public static DateTime AsLocal(this DateTime dateTime)
+		=> DateTime.SpecifyKind(dateTime, DateTimeKind.Local);
+
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> that is the <paramref name="timeDifference" /> before the
+	///     given <paramref name="dateTime" />.
+	/// </summary>
+	public static DateTime Before(this TimeSpan timeDifference, DateTime dateTime)
+		=> dateTime - timeDifference;
+
+	/// <summary>
+	///     Creates a <see cref="DateTime" /> that is the <paramref name="timeDifference" /> after the
+	///     specified <paramref name="dateTime" />.
+	/// </summary>
+	public static DateTime After(this TimeSpan timeDifference, DateTime dateTime)
+		=> dateTime + timeDifference;
+}

--- a/Source/aweXpect.Chronology/TimeSpanExtensions.cs
+++ b/Source/aweXpect.Chronology/TimeSpanExtensions.cs
@@ -5,135 +5,143 @@ namespace aweXpect.Chronology;
 /// <summary>
 ///     Extension methods for creating <see cref="TimeSpan" />.
 /// </summary>
+/// <example>
+///     Instead of <c>new TimeSpan(0, 5, 30)</c><br />
+///     you can write <c>5.Minutes(30.Seconds)</c>.
+/// </example>
 public static class TimeSpanExtensions
 {
 	/// <summary>
-	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" />.
-	/// </summary>
-	public static TimeSpan Days(this int days)
-		=> TimeSpan.FromDays(days);
-
-	/// <summary>
-	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" />.
-	/// </summary>
-	public static TimeSpan Days(this double days)
-		=> TimeSpan.FromDays(days);
-
-	/// <summary>
-	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
-	/// </summary>
-	public static TimeSpan Days(this int days, TimeSpan offset)
-		=> TimeSpan.FromDays(days).Add(offset);
-
-	/// <summary>
-	///     Converts the <paramref name="days" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
-	/// </summary>
-	public static TimeSpan Days(this double days, TimeSpan offset)
-		=> TimeSpan.FromDays(days).Add(offset);
-
-	/// <summary>
-	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" />.
-	/// </summary>
-	public static TimeSpan Hours(this int hours)
-		=> TimeSpan.FromHours(hours);
-
-	/// <summary>
-	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" />.
-	/// </summary>
-	public static TimeSpan Hours(this double hours)
-		=> TimeSpan.FromHours(hours);
-
-	/// <summary>
-	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
-	/// </summary>
-	public static TimeSpan Hours(this int hours, TimeSpan offset)
-		=> TimeSpan.FromHours(hours).Add(offset);
-
-	/// <summary>
-	///     Converts the <paramref name="hours" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
-	/// </summary>
-	public static TimeSpan Hours(this double hours, TimeSpan offset)
-		=> TimeSpan.FromHours(hours).Add(offset);
-
-	/// <summary>
-	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="milliseconds" />.
 	/// </summary>
 	public static TimeSpan Milliseconds(this int milliseconds)
 		=> TimeSpan.FromMilliseconds(milliseconds);
 
 	/// <summary>
-	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="milliseconds" />.
 	/// </summary>
 	public static TimeSpan Milliseconds(this double milliseconds)
 		=> TimeSpan.FromMilliseconds(milliseconds);
 
 	/// <summary>
-	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="milliseconds" />
+	///     and add the given <paramref name="offset" />.
 	/// </summary>
 	public static TimeSpan Milliseconds(this int milliseconds, TimeSpan offset)
 		=> TimeSpan.FromMilliseconds(milliseconds).Add(offset);
 
 	/// <summary>
-	///     Converts the <paramref name="milliseconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="milliseconds" />
+	///     and add the given <paramref name="offset" />.
 	/// </summary>
 	public static TimeSpan Milliseconds(this double milliseconds, TimeSpan offset)
 		=> TimeSpan.FromMilliseconds(milliseconds).Add(offset);
 
-	/// <summary>
-	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" />.
-	/// </summary>
-	public static TimeSpan Minutes(this int minutes)
-		=> TimeSpan.FromMinutes(minutes);
 
 	/// <summary>
-	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" />.
-	/// </summary>
-	public static TimeSpan Minutes(this double minutes)
-		=> TimeSpan.FromMinutes(minutes);
-
-	/// <summary>
-	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
-	/// </summary>
-	public static TimeSpan Minutes(this int minutes, TimeSpan offset)
-		=> TimeSpan.FromMinutes(minutes).Add(offset);
-
-	/// <summary>
-	///     Converts the <paramref name="minutes" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
-	/// </summary>
-	public static TimeSpan Minutes(this double minutes, TimeSpan offset)
-		=> TimeSpan.FromMinutes(minutes).Add(offset);
-
-	/// <summary>
-	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="seconds" />.
 	/// </summary>
 	public static TimeSpan Seconds(this int seconds)
 		=> TimeSpan.FromSeconds(seconds);
 
 	/// <summary>
-	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="seconds" />.
 	/// </summary>
 	public static TimeSpan Seconds(this double seconds)
 		=> TimeSpan.FromSeconds(seconds);
 
 	/// <summary>
-	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="seconds" />
+	///     and add the given <paramref name="offset" />.
 	/// </summary>
 	public static TimeSpan Seconds(this int seconds, TimeSpan offset)
 		=> TimeSpan.FromSeconds(seconds).Add(offset);
 
 	/// <summary>
-	///     Converts the <paramref name="seconds" /> into a corresponding <see cref="TimeSpan" /> and add the given
-	///     <paramref name="offset" />.
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="seconds" />
+	///     and add the given <paramref name="offset" />.
 	/// </summary>
 	public static TimeSpan Seconds(this double seconds, TimeSpan offset)
 		=> TimeSpan.FromSeconds(seconds).Add(offset);
+
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="minutes" />.
+	/// </summary>
+	public static TimeSpan Minutes(this int minutes)
+		=> TimeSpan.FromMinutes(minutes);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="minutes" />.
+	/// </summary>
+	public static TimeSpan Minutes(this double minutes)
+		=> TimeSpan.FromMinutes(minutes);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="minutes" />
+	///     and add the given <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Minutes(this int minutes, TimeSpan offset)
+		=> TimeSpan.FromMinutes(minutes).Add(offset);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="minutes" />
+	///     and add the given <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Minutes(this double minutes, TimeSpan offset)
+		=> TimeSpan.FromMinutes(minutes).Add(offset);
+
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="hours" />.
+	/// </summary>
+	public static TimeSpan Hours(this int hours)
+		=> TimeSpan.FromHours(hours);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="hours" />.
+	/// </summary>
+	public static TimeSpan Hours(this double hours)
+		=> TimeSpan.FromHours(hours);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="hours" />
+	///     and add the given <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Hours(this int hours, TimeSpan offset)
+		=> TimeSpan.FromHours(hours).Add(offset);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="hours" />
+	///     and add the given <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Hours(this double hours, TimeSpan offset)
+		=> TimeSpan.FromHours(hours).Add(offset);
+
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="days" />.
+	/// </summary>
+	public static TimeSpan Days(this int days)
+		=> TimeSpan.FromDays(days);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="days" />.
+	/// </summary>
+	public static TimeSpan Days(this double days)
+		=> TimeSpan.FromDays(days);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="days" />
+	///     and add the given <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Days(this int days, TimeSpan offset)
+		=> TimeSpan.FromDays(days).Add(offset);
+
+	/// <summary>
+	///     Creates a <see cref="TimeSpan" /> based on the number of <paramref name="days" />
+	///     and add the given <paramref name="offset" />.
+	/// </summary>
+	public static TimeSpan Days(this double days, TimeSpan offset)
+		=> TimeSpan.FromDays(days).Add(offset);
 }

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
@@ -2,6 +2,27 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect.Chronology
 {
+    public static class DateTimeExtensions
+    {
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime dateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime dateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
     public static class TimeSpanExtensions
     {
         public static System.TimeSpan Days(this double days) { }

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
@@ -2,6 +2,27 @@
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect.Chronology
 {
+    public static class DateTimeExtensions
+    {
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime dateTime) { }
+        public static System.DateTime April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0) { }
+        public static System.DateTime August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime dateTime) { }
+        public static System.DateTime December(this int day, int year) { }
+        public static System.DateTime February(this int day, int year) { }
+        public static System.DateTime January(this int day, int year) { }
+        public static System.DateTime July(this int day, int year) { }
+        public static System.DateTime June(this int day, int year) { }
+        public static System.DateTime March(this int day, int year) { }
+        public static System.DateTime May(this int day, int year) { }
+        public static System.DateTime November(this int day, int year) { }
+        public static System.DateTime October(this int day, int year) { }
+        public static System.DateTime September(this int day, int year) { }
+    }
     public static class TimeSpanExtensions
     {
         public static System.TimeSpan Days(this double days) { }

--- a/Tests/aweXpect.Chronology.Tests/DateTimeExtensionsTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/DateTimeExtensionsTests.cs
@@ -1,0 +1,203 @@
+﻿namespace aweXpect.Chronology.Tests;
+
+public class DateTimeExtensionsTests
+{
+	[Fact]
+	public async Task January_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 01, 29);
+
+		DateTime result = 29.January(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task February_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 02, 28);
+
+		DateTime result = 28.February(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task March_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 03, 27);
+
+		DateTime result = 27.March(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task April_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 04, 26);
+
+		DateTime result = 26.April(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task May_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 05, 25);
+
+		DateTime result = 25.May(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task June_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 06, 24);
+
+		DateTime result = 24.June(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task July_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 07, 23);
+
+		DateTime result = 23.July(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task August_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 08, 22);
+
+		DateTime result = 22.August(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task September_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 09, 21);
+
+		DateTime result = 21.September(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task October_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 10, 20);
+
+		DateTime result = 20.October(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task November_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 11, 19);
+
+		DateTime result = 19.November(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task December_ShouldReturnCorrectDateTime()
+	{
+		DateTime expected = new(2024, 12, 18);
+
+		DateTime result = 18.December(2024);
+
+		await That(result).Should().Be(expected);
+	}
+
+
+	[Fact]
+	public async Task At_WithTimeSpan_ShouldAddTime()
+	{
+		DateTime expected = new(2024, 12, 24, 18, 30, 15);
+
+		DateTime result = 24.December(2024).At(18.Hours(30.Minutes(15.Seconds())));
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task At_WithHourAndMinutes_ShouldAddTime()
+	{
+		DateTime expected = new(2024, 12, 24, 18, 30, 00);
+
+		DateTime result = 24.December(2024).At(18, 30);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task At_WithHourMinutesAndSeconds_ShouldAddTime()
+	{
+		DateTime expected = new(2024, 12, 24, 18, 30, 59);
+
+		DateTime result = 24.December(2024).At(18, 30, 59);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task At_WithHourMinutesSecondsAndMilliseconds_ShouldAddTime()
+	{
+		DateTime expected = new(2024, 12, 24, 18, 30, 0, 150, DateTimeKind.Unspecified);
+
+		DateTime result = 24.December(2024).At(18, 30, 0, 150);
+
+		await That(result).Should().Be(expected);
+	}
+
+
+	[Fact]
+	public async Task AsUtc_ShouldSetKindToUtc()
+	{
+		DateTime result = 24.December(2024).At(18, 30).AsUtc();
+
+		await That(result).Should().HaveKind(DateTimeKind.Utc);
+	}
+
+	[Fact]
+	public async Task AsLocal_ShouldSetKindToLocal()
+	{
+		DateTime result = 24.December(2024).At(18, 30).AsLocal();
+
+		await That(result).Should().HaveKind(DateTimeKind.Local);
+	}
+
+
+	[Fact]
+	public async Task Before_ShouldSubtractTimeSpanFromDateTime()
+	{
+		DateTime expected = new(2024, 12, 24, 21, 0, 0);
+
+		DateTime result = 3.Hours().Before(25.December(2024));
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
+	public async Task After_ShouldAddTimeSpanToDateTime()
+	{
+		DateTime expected = new(2024, 12, 24, 21, 0, 0);
+
+		DateTime result = 2.Days(12.Hours()).After(22.December(2024).At(9, 0));
+
+		await That(result).Should().Be(expected);
+	}
+}

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanExtensionsTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanExtensionsTests.cs
@@ -4,53 +4,7 @@ public class TimeSpanExtensionsTests
 {
 	[Theory]
 	[AutoData]
-	public async Task Double_Days_ShouldReturnCorrectTimeSpan(double days)
-	{
-		TimeSpan expected = TimeSpan.FromDays(days);
-
-		TimeSpan result = days.Days();
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Double_Days_WithOffset_ShouldReturnCorrectTimeSpan(double days,
-		TimeSpan offset)
-	{
-		TimeSpan expected = TimeSpan.FromDays(days) + offset;
-
-		TimeSpan result = days.Days(offset);
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Double_Hours_ShouldReturnCorrectTimeSpan(double hours)
-	{
-		TimeSpan expected = TimeSpan.FromHours(hours);
-
-		TimeSpan result = hours.Hours();
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Double_Hours_WithOffset_ShouldReturnCorrectTimeSpan(double hours,
-		TimeSpan offset)
-	{
-		TimeSpan expected = TimeSpan.FromHours(hours) + offset;
-
-		TimeSpan result = hours.Hours(offset);
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Double_Milliseconds_ShouldReturnCorrectTimeSpan(double milliseconds)
+	public async Task Milliseconds_Double_ShouldReturnCorrectTimeSpan(double milliseconds)
 	{
 		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds);
 
@@ -61,7 +15,7 @@ public class TimeSpanExtensionsTests
 
 	[Theory]
 	[AutoData]
-	public async Task Double_Milliseconds_WithOffset_ShouldReturnCorrectTimeSpan(
+	public async Task Milliseconds_Double_WithOffset_ShouldReturnCorrectTimeSpan(
 		double milliseconds, TimeSpan offset)
 	{
 		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds) + offset;
@@ -73,97 +27,7 @@ public class TimeSpanExtensionsTests
 
 	[Theory]
 	[AutoData]
-	public async Task Double_Minutes_ShouldReturnCorrectTimeSpan(double minutes)
-	{
-		TimeSpan expected = TimeSpan.FromMinutes(minutes);
-
-		TimeSpan result = minutes.Minutes();
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Double_Minutes_WithOffset_ShouldReturnCorrectTimeSpan(double minutes,
-		TimeSpan offset)
-	{
-		TimeSpan expected = TimeSpan.FromMinutes(minutes) + offset;
-
-		TimeSpan result = minutes.Minutes(offset);
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Double_Seconds_ShouldReturnCorrectTimeSpan(double seconds)
-	{
-		TimeSpan expected = TimeSpan.FromSeconds(seconds);
-
-		TimeSpan result = seconds.Seconds();
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Double_Seconds_WithOffset_ShouldReturnCorrectTimeSpan(double seconds,
-		TimeSpan offset)
-	{
-		TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
-
-		TimeSpan result = seconds.Seconds(offset);
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Int_Days_ShouldReturnCorrectTimeSpan(int days)
-	{
-		TimeSpan expected = days.Days();
-
-		TimeSpan result = days.Days();
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Int_Days_WithOffset_ShouldReturnCorrectTimeSpan(int days, TimeSpan offset)
-	{
-		TimeSpan expected = days.Days() + offset;
-
-		TimeSpan result = days.Days(offset);
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Int_Hours_ShouldReturnCorrectTimeSpan(int hours)
-	{
-		TimeSpan expected = TimeSpan.FromHours(hours);
-
-		TimeSpan result = hours.Hours();
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Int_Hours_WithOffset_ShouldReturnCorrectTimeSpan(int hours, TimeSpan offset)
-	{
-		TimeSpan expected = TimeSpan.FromHours(hours) + offset;
-
-		TimeSpan result = hours.Hours(offset);
-
-		await That(result).Should().Be(expected);
-	}
-
-	[Theory]
-	[AutoData]
-	public async Task Int_Milliseconds_ShouldReturnCorrectTimeSpan(int milliseconds)
+	public async Task Milliseconds_Int_ShouldReturnCorrectTimeSpan(int milliseconds)
 	{
 		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds);
 
@@ -174,7 +38,7 @@ public class TimeSpanExtensionsTests
 
 	[Theory]
 	[AutoData]
-	public async Task Int_Milliseconds_WithOffset_ShouldReturnCorrectTimeSpan(int milliseconds,
+	public async Task Milliseconds_Int_WithOffset_ShouldReturnCorrectTimeSpan(int milliseconds,
 		TimeSpan offset)
 	{
 		TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds) + offset;
@@ -184,9 +48,57 @@ public class TimeSpanExtensionsTests
 		await That(result).Should().Be(expected);
 	}
 
+
 	[Theory]
 	[AutoData]
-	public async Task Int_Minutes_ShouldReturnCorrectTimeSpan(int minutes)
+	public async Task Seconds_Double_ShouldReturnCorrectTimeSpan(double seconds)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds);
+
+		TimeSpan result = seconds.Seconds();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Seconds_Double_WithOffset_ShouldReturnCorrectTimeSpan(double seconds,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
+
+		TimeSpan result = seconds.Seconds(offset);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Seconds_Int_ShouldReturnCorrectTimeSpan(int seconds)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds);
+
+		TimeSpan result = seconds.Seconds();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Seconds_Int_WithOffset_ShouldReturnCorrectTimeSpan(int seconds,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
+
+		TimeSpan result = seconds.Seconds(offset);
+
+		await That(result).Should().Be(expected);
+	}
+
+
+	[Theory]
+	[AutoData]
+	public async Task Minutes_Double_ShouldReturnCorrectTimeSpan(double minutes)
 	{
 		TimeSpan expected = TimeSpan.FromMinutes(minutes);
 
@@ -197,7 +109,7 @@ public class TimeSpanExtensionsTests
 
 	[Theory]
 	[AutoData]
-	public async Task Int_Minutes_WithOffset_ShouldReturnCorrectTimeSpan(int minutes,
+	public async Task Minutes_Double_WithOffset_ShouldReturnCorrectTimeSpan(double minutes,
 		TimeSpan offset)
 	{
 		TimeSpan expected = TimeSpan.FromMinutes(minutes) + offset;
@@ -209,23 +121,115 @@ public class TimeSpanExtensionsTests
 
 	[Theory]
 	[AutoData]
-	public async Task Int_Seconds_ShouldReturnCorrectTimeSpan(int seconds)
+	public async Task Minutes_Int_ShouldReturnCorrectTimeSpan(int minutes)
 	{
-		TimeSpan expected = TimeSpan.FromSeconds(seconds);
+		TimeSpan expected = TimeSpan.FromMinutes(minutes);
 
-		TimeSpan result = seconds.Seconds();
+		TimeSpan result = minutes.Minutes();
 
 		await That(result).Should().Be(expected);
 	}
 
 	[Theory]
 	[AutoData]
-	public async Task Int_Seconds_WithOffset_ShouldReturnCorrectTimeSpan(int seconds,
+	public async Task Minutes_Int_WithOffset_ShouldReturnCorrectTimeSpan(int minutes,
 		TimeSpan offset)
 	{
-		TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
+		TimeSpan expected = TimeSpan.FromMinutes(minutes) + offset;
 
-		TimeSpan result = seconds.Seconds(offset);
+		TimeSpan result = minutes.Minutes(offset);
+
+		await That(result).Should().Be(expected);
+	}
+
+
+	[Theory]
+	[AutoData]
+	public async Task Hours_Double_ShouldReturnCorrectTimeSpan(double hours)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours);
+
+		TimeSpan result = hours.Hours();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Hours_Double_WithOffset_ShouldReturnCorrectTimeSpan(double hours,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours) + offset;
+
+		TimeSpan result = hours.Hours(offset);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Hours_Int_ShouldReturnCorrectTimeSpan(int hours)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours);
+
+		TimeSpan result = hours.Hours();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Hours_Int_WithOffset_ShouldReturnCorrectTimeSpan(int hours, TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromHours(hours) + offset;
+
+		TimeSpan result = hours.Hours(offset);
+
+		await That(result).Should().Be(expected);
+	}
+
+
+	[Theory]
+	[AutoData]
+	public async Task Days_Double_ShouldReturnCorrectTimeSpan(double days)
+	{
+		TimeSpan expected = TimeSpan.FromDays(days);
+
+		TimeSpan result = days.Days();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Days_Double_WithOffset_ShouldReturnCorrectTimeSpan(double days,
+		TimeSpan offset)
+	{
+		TimeSpan expected = TimeSpan.FromDays(days) + offset;
+
+		TimeSpan result = days.Days(offset);
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Days_Int_ShouldReturnCorrectTimeSpan(int days)
+	{
+		TimeSpan expected = days.Days();
+
+		TimeSpan result = days.Days();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Theory]
+	[AutoData]
+	public async Task Days_Int_WithOffset_ShouldReturnCorrectTimeSpan(int days, TimeSpan offset)
+	{
+		TimeSpan expected = days.Days() + offset;
+
+		TimeSpan result = days.Days(offset);
 
 		await That(result).Should().Be(expected);
 	}


### PR DESCRIPTION
Add extension methods on `int` for each month that allow creating a `DateTime`:

```csharp
// ↓ Using traditional creation of DateTime
DateTime time = new DateTime(2024, 12, 24);
DateTime time = 24.December(2024);
// ↑ Using the extension methods from this library
```

It is also possible to specify a time:
```csharp
DateTime time = 24.December(2024).At(18, 30);
```

It is also possible combine this with the `TimeSpan` extensions:
```csharp
DateTime time = 3.Hours().Before(25.December(2024));
```