### PR TITLE
feat: add unary minus operator for `TimeSpanBuilder`

### DIFF
--- a/Source/aweXpect.Chronology/TimeSpanBuilder.cs
+++ b/Source/aweXpect.Chronology/TimeSpanBuilder.cs
@@ -21,6 +21,12 @@ public readonly struct TimeSpanBuilder(TimeSpan value)
 	public static implicit operator TimeSpan(TimeSpanBuilder builder)
 		=> builder._value;
 
+	/// <summary>
+	///     Returns a new <see cref="TimeSpanBuilder" /> whose value is the negated value of this <paramref name="instance" />.
+	/// </summary>
+	public static TimeSpanBuilder operator -(TimeSpanBuilder instance)
+		=> new(instance._value.Negate());
+
 #if NET8_0_OR_GREATER
 	/// <summary>
 	///     Implicitly casts the <see cref="TimeSpanBuilder" /> to a <see cref="TimeOnly" />.

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
@@ -58,6 +58,7 @@ namespace aweXpect.Chronology
         public static System.TimeSpan op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
         public static System.TimeOnly op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator +(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder instance) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
     }
     public static class TimeSpanBuilderExtensions

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
@@ -52,6 +52,7 @@ namespace aweXpect.Chronology
         public TimeSpanBuilder(System.TimeSpan value) { }
         public static System.TimeSpan op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator +(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder instance) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
     }
     public static class TimeSpanBuilderExtensions

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanBuilderTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanBuilderTests.cs
@@ -25,6 +25,16 @@ public sealed class TimeSpanBuilderTests
 	}
 
 	[Fact]
+	public async Task UnaryMinusOperator_ShouldReturnNegatedValue()
+	{
+		TimeSpan expected = TimeSpan.FromHours(-1);
+		
+		TimeSpan result = -1.Hours();
+
+		await That(result).Should().Be(expected);
+	}
+
+	[Fact]
 	public async Task ImplicitOperator_ShouldConvertToTimeSpan()
 	{
 		TimeSpan expected = new(2, 3, 4);


### PR DESCRIPTION
Support writing, e.g.
```csharp
TimeSpan timeout = -1.Seconds();
```