### PR TITLE
refactor: use xunit v3 as testing framework

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,8 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="0.7.0"/>
-		<PackageVersion Include="aweXpect.Core" Version="0.7.0"/>
+		<PackageVersion Include="aweXpect" Version="0.14.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="MinVer" Version="6.0.0"/>
@@ -24,8 +23,8 @@
 		<PackageVersion Include="NUnit" Version="4.2.2"/>
 		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
 		<PackageVersion Include="NUnit.Analyzers" Version="4.4.0"/>
-		<PackageVersion Include="xunit" Version="2.9.2"/>
-		<PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2"/>
+		<PackageVersion Include="xunit.v3" Version="1.0.0"/>
+		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
 		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.2"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.1.0"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="0.14.0"/>
+		<PackageVersion Include="aweXpect" Version="0.14.1"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="MinVer" Version="6.0.0"/>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,12 +20,8 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-		<PackageVersion Include="NUnit" Version="4.2.2"/>
-		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
-		<PackageVersion Include="NUnit.Analyzers" Version="4.4.0"/>
 		<PackageVersion Include="xunit.v3" Version="1.0.0"/>
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
-		<PackageVersion Include="AutoFixture.Xunit2" Version="4.18.1"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.2"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.1.0"/>
 	</ItemGroup>

--- a/Pipeline/Build.UnitTest.cs
+++ b/Pipeline/Build.UnitTest.cs
@@ -1,11 +1,8 @@
+using System.Linq;
 using Nuke.Common;
-using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
-using Nuke.Common.Tools.Xunit;
-using System.Linq;
-using static Nuke.Common.Tools.Xunit.XunitTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 // ReSharper disable AllUnderscoreLocalParameterName
@@ -15,7 +12,6 @@ namespace Build;
 partial class Build
 {
 	Target UnitTests => _ => _
-		.DependsOn(DotNetFrameworkUnitTests)
 		.DependsOn(DotNetUnitTests);
 
 	Project[] UnitTestProjects =>
@@ -23,39 +19,15 @@ partial class Build
 		Solution.Tests.aweXpect_Chronology_Tests
 	];
 
-	Target DotNetFrameworkUnitTests => _ => _
-		.Unlisted()
-		.DependsOn(Compile)
-		.OnlyWhenDynamic(() => EnvironmentInfo.IsWin)
-		.Executes(() =>
-		{
-			string net48 = "net48";
-			DotNetTest(s => s
-				.SetConfiguration(Configuration)
-				.SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
-				.EnableNoBuild()
-				.SetDataCollector("XPlat Code Coverage")
-				.SetResultsDirectory(TestResultsDirectory)
-				.CombineWith(
-					UnitTestProjects,
-					(settings, project) => settings
-						.SetProjectFile(project)
-						.CombineWith(
-							project.GetTargetFrameworks()?.Where(x => x == net48),
-							(frameworkSettings, framework) => frameworkSettings
-								.SetFramework(framework)
-								.AddLoggers($"trx;LogFileName={project.Name}_{framework}.trx")
-						)
-				), completeOnFailure: true
-			);
-		});
-
 	Target DotNetUnitTests => _ => _
 		.Unlisted()
 		.DependsOn(Compile)
 		.Executes(() =>
 		{
-			string net48 = "net48";
+			string[] excludedFrameworks =
+				EnvironmentInfo.IsWin
+					? []
+					: ["net48"];
 			DotNetTest(s => s
 					.SetConfiguration(Configuration)
 					.SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
@@ -67,7 +39,7 @@ partial class Build
 						(settings, project) => settings
 							.SetProjectFile(project)
 							.CombineWith(
-								project.GetTargetFrameworks()?.Except([net48]),
+								project.GetTargetFrameworks()?.Except(excludedFrameworks),
 								(frameworkSettings, framework) => frameworkSettings
 									.SetFramework(framework)
 									.AddLoggers($"trx;LogFileName={project.Name}_{framework}.trx")

--- a/Pipeline/Build.UnitTest.cs
+++ b/Pipeline/Build.UnitTest.cs
@@ -32,7 +32,7 @@ partial class Build
 			string[] testAssemblies = UnitTestProjects
 				.SelectMany(project =>
 					project.Directory.GlobFiles(
-						$"bin/{(Configuration == Configuration.Debug ? "Debug" : "Release")}/net48/*.Tests.dll"))
+						$"bin/{(Configuration == Configuration.Debug ? "Debug" : "Release")}/net48/*.Tests.exe"))
 				.Select(p => p.ToString())
 				.ToArray();
 

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -14,15 +14,16 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<NoWarn>701;1702;CA1845</NoWarn>
+		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="xunit"/>
+		<PackageReference Include="aweXpect"/>
+		<PackageReference Include="xunit.v3"/>
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
-		<PackageReference Include="AutoFixture.Xunit2"/>
 		<PackageReference Include="Microsoft.NET.Test.Sdk"/>
 		<PackageReference Include="Nullable">
 			<PrivateAssets>all</PrivateAssets>

--- a/Tests/aweXpect.Chronology.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Chronology.Api.Tests/ApiAcceptance.cs
@@ -1,16 +1,15 @@
 ﻿using System;
-using NUnit.Framework;
+using System.Threading.Tasks;
 
-namespace aweXpect.Api.Tests;
+namespace aweXpect.Chronology.Api.Tests;
 
 public sealed class ApiAcceptance
 {
 	/// <summary>
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
-	[TestCase]
-	[Explicit]
-	public void AcceptApiChanges()
+	[Fact(Explicit = true)]
+	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =
 		[
@@ -27,6 +26,6 @@ public sealed class ApiAcceptance
 			}
 		}
 
-		Assert.That(assemblyNames, Is.Not.Empty);
+		await Expect.That(assemblyNames).Should().NotBeEmpty();
 	}
 }

--- a/Tests/aweXpect.Chronology.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Chronology.Api.Tests/ApiApprovalTests.cs
@@ -1,7 +1,6 @@
-﻿using System.Collections;
-using NUnit.Framework;
+﻿using System.Threading.Tasks;
 
-namespace aweXpect.Api.Tests;
+namespace aweXpect.Chronology.Api.Tests;
 
 /// <summary>
 ///     Whenever a test fails, this means that the public API surface changed.
@@ -10,29 +9,18 @@ namespace aweXpect.Api.Tests;
 /// </summary>
 public sealed class ApiApprovalTests
 {
-	[TestCaseSource(typeof(TargetFrameworksTheoryData))]
-	public void VerifyPublicApiForAweXpectChronology(string framework)
+	public static TheoryData<string> TargetFrameworksTheoryData
+		=> new(Helper.GetTargetFrameworks());
+
+	[Theory]
+	[MemberData(nameof(TargetFrameworksTheoryData))]
+	public async Task VerifyPublicApiForAweXpectChronology(string framework)
 	{
 		const string assemblyName = "aweXpect.Chronology";
 
 		string publicApi = Helper.CreatePublicApi(framework, assemblyName);
 		string expectedApi = Helper.GetExpectedApi(framework, assemblyName);
 
-		Assert.That(publicApi, Is.EqualTo(expectedApi));
-	}
-
-	private sealed class TargetFrameworksTheoryData : IEnumerable
-	{
-		#region IEnumerable Members
-
-		public IEnumerator GetEnumerator()
-		{
-			foreach (string targetFramework in Helper.GetTargetFrameworks())
-			{
-				yield return new object[] { targetFramework };
-			}
-		}
-
-		#endregion
+		await Expect.That(publicApi).Should().Be(expectedApi);
 	}
 }

--- a/Tests/aweXpect.Chronology.Api.Tests/Helper.cs
+++ b/Tests/aweXpect.Chronology.Api.Tests/Helper.cs
@@ -7,7 +7,7 @@ using System.Xml.Linq;
 using System.Xml.XPath;
 using PublicApiGenerator;
 
-namespace aweXpect.Api.Tests;
+namespace aweXpect.Chronology.Api.Tests;
 
 public static class Helper
 {

--- a/Tests/aweXpect.Chronology.Api.Tests/aweXpect.Chronology.Api.Tests.csproj
+++ b/Tests/aweXpect.Chronology.Api.Tests/aweXpect.Chronology.Api.Tests.csproj
@@ -9,11 +9,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Remove="xunit"/>
-		<PackageReference Remove="xunit.runner.visualstudio"/>
-		<PackageReference Include="NUnit"/>
-		<PackageReference Include="NUnit.Analyzers"/>
-		<PackageReference Include="NUnit3TestAdapter"/>
 		<PackageReference Include="PublicApiGenerator"/>
 	</ItemGroup>
 

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.DaysTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.DaysTests.cs
@@ -5,7 +5,7 @@ public sealed partial class TimeSpanExtensions
 	public sealed class DaysTests
 	{
 		[Theory]
-		[AutoData]
+		[InlineData(1.2)]
 		public async Task Days_Double_ShouldReturnCorrectTimeSpan(double days)
 		{
 			TimeSpan expected = TimeSpan.FromDays(days);
@@ -16,10 +16,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1.2, 3.4)]
 		public async Task Days_Double_WithOffset_ShouldReturnCorrectTimeSpan(double days,
-			TimeSpan offset)
+			double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromDays(days) + offset;
 
 			TimeSpan result = days.Days(offset);
@@ -28,7 +29,7 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1)]
 		public async Task Days_Int_ShouldReturnCorrectTimeSpan(int days)
 		{
 			TimeSpan expected = days.Days();
@@ -39,9 +40,10 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task Days_Int_WithOffset_ShouldReturnCorrectTimeSpan(int days, TimeSpan offset)
+		[InlineData(1, 3.4)]
+		public async Task Days_Int_WithOffset_ShouldReturnCorrectTimeSpan(int days, double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = days.Days() + offset;
 
 			TimeSpan result = days.Days(offset);

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.HoursTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.HoursTests.cs
@@ -5,7 +5,7 @@ public sealed partial class TimeSpanExtensions
 	public sealed class HoursTests
 	{
 		[Theory]
-		[AutoData]
+		[InlineData(1.2)]
 		public async Task Hours_Double_ShouldReturnCorrectTimeSpan(double hours)
 		{
 			TimeSpan expected = TimeSpan.FromHours(hours);
@@ -16,10 +16,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1.2, 3.4)]
 		public async Task Hours_Double_WithOffset_ShouldReturnCorrectTimeSpan(double hours,
-			TimeSpan offset)
+			double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromHours(hours) + offset;
 
 			TimeSpan result = hours.Hours(offset);
@@ -28,7 +29,7 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1)]
 		public async Task Hours_Int_ShouldReturnCorrectTimeSpan(int hours)
 		{
 			TimeSpan expected = TimeSpan.FromHours(hours);
@@ -39,9 +40,10 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
-		public async Task Hours_Int_WithOffset_ShouldReturnCorrectTimeSpan(int hours, TimeSpan offset)
+		[InlineData(1, 3.4)]
+		public async Task Hours_Int_WithOffset_ShouldReturnCorrectTimeSpan(int hours, double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromHours(hours) + offset;
 
 			TimeSpan result = hours.Hours(offset);

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.MillisecondsTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.MillisecondsTests.cs
@@ -5,7 +5,7 @@ public sealed partial class TimeSpanExtensions
 	public sealed class MillisecondsTests
 	{
 		[Theory]
-		[AutoData]
+		[InlineData(1.2)]
 		public async Task Milliseconds_Double_ShouldReturnCorrectTimeSpan(double milliseconds)
 		{
 			TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds);
@@ -16,10 +16,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1.2, 3.4)]
 		public async Task Milliseconds_Double_WithOffset_ShouldReturnCorrectTimeSpan(
-			double milliseconds, TimeSpan offset)
+			double milliseconds, double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds) + offset;
 
 			TimeSpan result = milliseconds.Milliseconds(offset);
@@ -28,7 +29,7 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1)]
 		public async Task Milliseconds_Int_ShouldReturnCorrectTimeSpan(int milliseconds)
 		{
 			TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds);
@@ -39,10 +40,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1, 3.4)]
 		public async Task Milliseconds_Int_WithOffset_ShouldReturnCorrectTimeSpan(int milliseconds,
-			TimeSpan offset)
+			double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromMilliseconds(milliseconds) + offset;
 
 			TimeSpan result = milliseconds.Milliseconds(offset);

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.MinutesTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.MinutesTests.cs
@@ -5,7 +5,7 @@ public sealed partial class TimeSpanExtensions
 	public sealed class MinutesTests
 	{
 		[Theory]
-		[AutoData]
+		[InlineData(1.2)]
 		public async Task Minutes_Double_ShouldReturnCorrectTimeSpan(double minutes)
 		{
 			TimeSpan expected = TimeSpan.FromMinutes(minutes);
@@ -16,10 +16,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1.2, 3.4)]
 		public async Task Minutes_Double_WithOffset_ShouldReturnCorrectTimeSpan(double minutes,
-			TimeSpan offset)
+			double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromMinutes(minutes) + offset;
 
 			TimeSpan result = minutes.Minutes(offset);
@@ -28,7 +29,7 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1)]
 		public async Task Minutes_Int_ShouldReturnCorrectTimeSpan(int minutes)
 		{
 			TimeSpan expected = TimeSpan.FromMinutes(minutes);
@@ -39,10 +40,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1, 3.4)]
 		public async Task Minutes_Int_WithOffset_ShouldReturnCorrectTimeSpan(int minutes,
-			TimeSpan offset)
+			double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromMinutes(minutes) + offset;
 
 			TimeSpan result = minutes.Minutes(offset);

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.SecondsTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanExtensions.SecondsTests.cs
@@ -5,7 +5,7 @@ public sealed partial class TimeSpanExtensions
 	public sealed class SecondsTests
 	{
 		[Theory]
-		[AutoData]
+		[InlineData(1.2)]
 		public async Task Seconds_Double_ShouldReturnCorrectTimeSpan(double seconds)
 		{
 			TimeSpan expected = TimeSpan.FromSeconds(seconds);
@@ -16,10 +16,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1.2, 3.4)]
 		public async Task Seconds_Double_WithOffset_ShouldReturnCorrectTimeSpan(double seconds,
-			TimeSpan offset)
+			double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
 
 			TimeSpan result = seconds.Seconds(offset);
@@ -28,7 +29,7 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1)]
 		public async Task Seconds_Int_ShouldReturnCorrectTimeSpan(int seconds)
 		{
 			TimeSpan expected = TimeSpan.FromSeconds(seconds);
@@ -39,10 +40,11 @@ public sealed partial class TimeSpanExtensions
 		}
 
 		[Theory]
-		[AutoData]
+		[InlineData(1, 3.4)]
 		public async Task Seconds_Int_WithOffset_ShouldReturnCorrectTimeSpan(int seconds,
-			TimeSpan offset)
+			double offsetSeconds)
 		{
+			TimeSpan offset = TimeSpan.FromSeconds(offsetSeconds);
 			TimeSpan expected = TimeSpan.FromSeconds(seconds) + offset;
 
 			TimeSpan result = seconds.Seconds(offset);

--- a/Tests/aweXpect.Chronology.Tests/Usings.cs
+++ b/Tests/aweXpect.Chronology.Tests/Usings.cs
@@ -1,8 +1,4 @@
 ﻿global using System;
 global using System.Threading.Tasks;
-global using AutoFixture.Xunit2;
 global using Xunit;
-global using Xunit.Sdk;
-global using aweXpect.Formatting;
-global using static aweXpect.Formatting.Format;
 global using static aweXpect.Expect;

--- a/Tests/aweXpect.Chronology.Tests/aweXpect.Chronology.Tests.csproj
+++ b/Tests/aweXpect.Chronology.Tests/aweXpect.Chronology.Tests.csproj
@@ -4,8 +4,4 @@
 		<ProjectReference Include="..\..\Source\aweXpect.Chronology\aweXpect.Chronology.csproj"/>
 	</ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="aweXpect"/>
-	</ItemGroup>
-
 </Project>


### PR DESCRIPTION
Migrate to [xunit v3](https://xunit.net/docs/getting-started/v3/migration).