### PR TITLE
revert: xunit v3 migration

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -20,7 +20,10 @@
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.12.0"/>
-		<PackageVersion Include="xunit.v3" Version="1.0.0"/>
+		<PackageVersion Include="NUnit" Version="4.2.2"/>
+		<PackageVersion Include="NUnit3TestAdapter" Version="4.6.0"/>
+		<PackageVersion Include="NUnit.Analyzers" Version="4.4.0"/>
+		<PackageVersion Include="xunit" Version="2.9.2"/>
 		<PackageVersion Include="xunit.runner.visualstudio" Version="3.0.0"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.2"/>
 		<PackageVersion Include="PublicApiGenerator" Version="11.1.0"/>

--- a/Pipeline/Build.UnitTest.cs
+++ b/Pipeline/Build.UnitTest.cs
@@ -1,8 +1,11 @@
-using System.Linq;
 using Nuke.Common;
+using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tooling;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.Xunit;
+using System.Linq;
+using static Nuke.Common.Tools.Xunit.XunitTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
 // ReSharper disable AllUnderscoreLocalParameterName
@@ -12,6 +15,7 @@ namespace Build;
 partial class Build
 {
 	Target UnitTests => _ => _
+		.DependsOn(DotNetFrameworkUnitTests)
 		.DependsOn(DotNetUnitTests);
 
 	Project[] UnitTestProjects =>
@@ -19,15 +23,33 @@ partial class Build
 		Solution.Tests.aweXpect_Chronology_Tests
 	];
 
+	Target DotNetFrameworkUnitTests => _ => _
+		.Unlisted()
+		.DependsOn(Compile)
+		.OnlyWhenDynamic(() => EnvironmentInfo.IsWin)
+		.Executes(() =>
+		{
+			string[] testAssemblies = UnitTestProjects
+				.SelectMany(project =>
+					project.Directory.GlobFiles(
+						$"bin/{(Configuration == Configuration.Debug ? "Debug" : "Release")}/net48/*.Tests.dll"))
+				.Select(p => p.ToString())
+				.ToArray();
+
+			Assert.NotEmpty(testAssemblies.ToList());
+
+			Xunit2(s => s
+				.SetFramework("net48")
+				.AddTargetAssemblies(testAssemblies)
+			);
+		});
+
 	Target DotNetUnitTests => _ => _
 		.Unlisted()
 		.DependsOn(Compile)
 		.Executes(() =>
 		{
-			string[] excludedFrameworks =
-				EnvironmentInfo.IsWin
-					? []
-					: ["net48"];
+			string net48 = "net48";
 			DotNetTest(s => s
 					.SetConfiguration(Configuration)
 					.SetProcessEnvironmentVariable("DOTNET_CLI_UI_LANGUAGE", "en-US")
@@ -39,7 +61,7 @@ partial class Build
 						(settings, project) => settings
 							.SetProjectFile(project)
 							.CombineWith(
-								project.GetTargetFrameworks()?.Except(excludedFrameworks),
+								project.GetTargetFrameworks()?.Except([net48]),
 								(frameworkSettings, framework) => frameworkSettings
 									.SetFramework(framework)
 									.AddLoggers($"trx;LogFileName={project.Name}_{framework}.trx")

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -14,12 +14,11 @@
 		<IsPackable>false</IsPackable>
 		<IsTestProject>true</IsTestProject>
 		<NoWarn>701;1702;CA1845</NoWarn>
-		<OutputType>Exe</OutputType>
 	</PropertyGroup>
 
 	<ItemGroup>
 		<PackageReference Include="aweXpect"/>
-		<PackageReference Include="xunit.v3"/>
+		<PackageReference Include="xunit"/>
 		<PackageReference Include="xunit.runner.visualstudio">
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 			<PrivateAssets>all</PrivateAssets>
@@ -34,9 +33,4 @@
 			<PrivateAssets>all</PrivateAssets>
 		</PackageReference>
 	</ItemGroup>
-
-	<ItemGroup>
-		<Using Include="Xunit"/>
-	</ItemGroup>
-
 </Project>

--- a/Tests/aweXpect.Chronology.Api.Tests/ApiAcceptance.cs
+++ b/Tests/aweXpect.Chronology.Api.Tests/ApiAcceptance.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace aweXpect.Chronology.Api.Tests;
 
@@ -8,7 +9,8 @@ public sealed class ApiAcceptance
 	/// <summary>
 	///     Execute this test to update the expected public API to the current API surface.
 	/// </summary>
-	[Fact(Explicit = true)]
+	[TestCase]
+	[Explicit]
 	public async Task AcceptApiChanges()
 	{
 		string[] assemblyNames =

--- a/Tests/aweXpect.Chronology.Api.Tests/ApiApprovalTests.cs
+++ b/Tests/aweXpect.Chronology.Api.Tests/ApiApprovalTests.cs
@@ -1,4 +1,6 @@
-﻿using System.Threading.Tasks;
+﻿using System.Collections;
+using System.Threading.Tasks;
+using NUnit.Framework;
 
 namespace aweXpect.Chronology.Api.Tests;
 
@@ -9,11 +11,7 @@ namespace aweXpect.Chronology.Api.Tests;
 /// </summary>
 public sealed class ApiApprovalTests
 {
-	public static TheoryData<string> TargetFrameworksTheoryData
-		=> new(Helper.GetTargetFrameworks());
-
-	[Theory]
-	[MemberData(nameof(TargetFrameworksTheoryData))]
+	[TestCaseSource(typeof(TargetFrameworksTheoryData))]
 	public async Task VerifyPublicApiForAweXpectChronology(string framework)
 	{
 		const string assemblyName = "aweXpect.Chronology";
@@ -22,5 +20,19 @@ public sealed class ApiApprovalTests
 		string expectedApi = Helper.GetExpectedApi(framework, assemblyName);
 
 		await Expect.That(publicApi).Should().Be(expectedApi);
+	}
+	private sealed class TargetFrameworksTheoryData : IEnumerable
+	{
+		#region IEnumerable Members
+
+		public IEnumerator GetEnumerator()
+		{
+			foreach (string targetFramework in Helper.GetTargetFrameworks())
+			{
+				yield return new object[] { targetFramework };
+			}
+		}
+
+		#endregion
 	}
 }

--- a/Tests/aweXpect.Chronology.Api.Tests/aweXpect.Chronology.Api.Tests.csproj
+++ b/Tests/aweXpect.Chronology.Api.Tests/aweXpect.Chronology.Api.Tests.csproj
@@ -9,6 +9,11 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<PackageReference Remove="xunit"/>
+		<PackageReference Remove="xunit.runner.visualstudio"/>
+		<PackageReference Include="NUnit"/>
+		<PackageReference Include="NUnit.Analyzers"/>
+		<PackageReference Include="NUnit3TestAdapter"/>
 		<PackageReference Include="PublicApiGenerator"/>
 	</ItemGroup>
 


### PR DESCRIPTION
Revert back the xunit v3 migration from #14, as [Stryker.NET doesn't handle xUnit v3 properly](https://github.com/stryker-mutator/stryker-net/issues/3117).