### PR TITLE
refactor: remove MinVer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,3 @@ In order to support this, static code analysis is performed using [SonarCloud](h
 - have a code coverage of > 90%
 
 Additionally each push to the `main` branch checks the quality of the unit tests using [Stryker.NET](https://stryker-mutator.io/docs/stryker-net/introduction/).
-
-## Versioning
-This project uses [MinVer](https://github.com/adamralph/minver) for versioning.  

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,10 +3,9 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="0.17.0"/>
+		<PackageVersion Include="aweXpect" Version="0.19.1"/>
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="MinVer" Version="6.0.0"/>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>
 	</ItemGroup>
 	<ItemGroup>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -12,7 +12,6 @@
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>
 		<PackageReadmeFile>Docs/README.md</PackageReadmeFile>
-		<MinVerTagPrefix>v</MinVerTagPrefix>
 	</PropertyGroup>
 
 	<PropertyGroup>
@@ -39,10 +38,6 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="MinVer">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
 		<PackageReference Include="Nullable">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Remove the no longer required dependency on [MinVer](https://github.com/adamralph/minver) as the version is set via Nuke in the build pipeline