### PR TITLE
fix: push nuget packages on macos

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -144,7 +144,7 @@ jobs:
     push:
         name: "Push"
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}
-        runs-on: ubuntu-latest
+        runs-on: macos-latest
         environment: production
         needs: [ pack ]
         permissions:


### PR DESCRIPTION
use macos for nuget push, as it worked [here](https://github.com/aweXpect/aweXpect.Testably/pull/22)