### PR TITLE
feat: add multiply and divison operator for `TimeSpanBuilder`

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,7 +3,7 @@
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 	</PropertyGroup>
 	<ItemGroup>
-		<PackageVersion Include="aweXpect" Version="0.24.0"/>
+		<PackageVersion Include="aweXpect" Version="0.33.0"/>
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Nullable" Version="1.3.1"/>

--- a/Source/aweXpect.Chronology/TimeSpanBuilder.cs
+++ b/Source/aweXpect.Chronology/TimeSpanBuilder.cs
@@ -19,17 +19,13 @@ public readonly struct TimeSpanBuilder(TimeSpan value)
 	///     Implicitly casts the <see cref="TimeSpanBuilder" /> to a <see cref="TimeSpan" />.
 	/// </summary>
 	public static implicit operator TimeSpan(TimeSpanBuilder builder)
-	{
-		return builder._value;
-	}
+		=> builder._value;
 
 	/// <summary>
 	///     Returns a new <see cref="TimeSpanBuilder" /> whose value is the negated value of this <paramref name="instance" />.
 	/// </summary>
 	public static TimeSpanBuilder operator -(TimeSpanBuilder instance)
-	{
-		return new TimeSpanBuilder(instance._value.Negate());
-	}
+		=> new(instance._value.Negate());
 
 #if NET8_0_OR_GREATER
 	/// <summary>
@@ -43,31 +39,23 @@ public readonly struct TimeSpanBuilder(TimeSpan value)
 	///     Adds a <see cref="TimeSpan" /> to the <see cref="TimeSpan" />.
 	/// </summary>
 	public static TimeSpanBuilder operator +(TimeSpanBuilder builder, TimeSpan time)
-	{
-		return new TimeSpanBuilder(builder._value + time);
-	}
+		=> new(builder._value + time);
 
 	/// <summary>
 	///     Subtracts a <see cref="TimeSpan" /> from the <see cref="TimeSpan" />.
 	/// </summary>
 	public static TimeSpanBuilder operator -(TimeSpanBuilder builder, TimeSpan time)
-	{
-		return new TimeSpanBuilder(builder._value - time);
-	}
+		=> new(builder._value - time);
 
 	/// <summary>
 	///     Multiplies a <see cref="TimeSpan" /> with the <paramref name="multiplier" />.
 	/// </summary>
 	public static TimeSpanBuilder operator *(TimeSpanBuilder builder, double multiplier)
-	{
-		return new TimeSpanBuilder(TimeSpan.FromTicks((long)(builder._value.Ticks * multiplier)));
-	}
+		=> new(TimeSpan.FromTicks((long)(builder._value.Ticks * multiplier)));
 
 	/// <summary>
 	///     Divides a <see cref="TimeSpan" /> by the <paramref name="divisor" />.
 	/// </summary>
 	public static TimeSpanBuilder operator /(TimeSpanBuilder builder, double divisor)
-	{
-		return new TimeSpanBuilder(TimeSpan.FromTicks((long)(builder._value.Ticks / divisor)));
-	}
+		=> new(TimeSpan.FromTicks((long)(builder._value.Ticks / divisor)));
 }

--- a/Source/aweXpect.Chronology/TimeSpanBuilder.cs
+++ b/Source/aweXpect.Chronology/TimeSpanBuilder.cs
@@ -19,13 +19,17 @@ public readonly struct TimeSpanBuilder(TimeSpan value)
 	///     Implicitly casts the <see cref="TimeSpanBuilder" /> to a <see cref="TimeSpan" />.
 	/// </summary>
 	public static implicit operator TimeSpan(TimeSpanBuilder builder)
-		=> builder._value;
+	{
+		return builder._value;
+	}
 
 	/// <summary>
 	///     Returns a new <see cref="TimeSpanBuilder" /> whose value is the negated value of this <paramref name="instance" />.
 	/// </summary>
 	public static TimeSpanBuilder operator -(TimeSpanBuilder instance)
-		=> new(instance._value.Negate());
+	{
+		return new TimeSpanBuilder(instance._value.Negate());
+	}
 
 #if NET8_0_OR_GREATER
 	/// <summary>
@@ -39,11 +43,31 @@ public readonly struct TimeSpanBuilder(TimeSpan value)
 	///     Adds a <see cref="TimeSpan" /> to the <see cref="TimeSpan" />.
 	/// </summary>
 	public static TimeSpanBuilder operator +(TimeSpanBuilder builder, TimeSpan time)
-		=> new(builder._value + time);
+	{
+		return new TimeSpanBuilder(builder._value + time);
+	}
 
 	/// <summary>
 	///     Subtracts a <see cref="TimeSpan" /> from the <see cref="TimeSpan" />.
 	/// </summary>
 	public static TimeSpanBuilder operator -(TimeSpanBuilder builder, TimeSpan time)
-		=> new(builder._value - time);
+	{
+		return new TimeSpanBuilder(builder._value - time);
+	}
+
+	/// <summary>
+	///     Multiplies a <see cref="TimeSpan" /> with the <paramref name="multiplier" />.
+	/// </summary>
+	public static TimeSpanBuilder operator *(TimeSpanBuilder builder, double multiplier)
+	{
+		return new TimeSpanBuilder(TimeSpan.FromTicks((long)(builder._value.Ticks * multiplier)));
+	}
+
+	/// <summary>
+	///     Divides a <see cref="TimeSpan" /> by the <paramref name="divisor" />.
+	/// </summary>
+	public static TimeSpanBuilder operator /(TimeSpanBuilder builder, double divisor)
+	{
+		return new TimeSpanBuilder(TimeSpan.FromTicks((long)(builder._value.Ticks / divisor)));
+	}
 }

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
@@ -73,9 +73,11 @@ namespace aweXpect.Chronology
         public TimeSpanBuilder(System.TimeSpan value) { }
         public static System.TimeSpan op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
         public static System.TimeOnly op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator *(aweXpect.Chronology.TimeSpanBuilder builder, double multiplier) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator +(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder instance) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator /(aweXpect.Chronology.TimeSpanBuilder builder, double divisor) { }
     }
     public static class TimeSpanBuilderExtensions
     {

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
@@ -65,9 +65,11 @@ namespace aweXpect.Chronology
     {
         public TimeSpanBuilder(System.TimeSpan value) { }
         public static System.TimeSpan op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator *(aweXpect.Chronology.TimeSpanBuilder builder, double multiplier) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator +(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder instance) { }
         public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator /(aweXpect.Chronology.TimeSpanBuilder builder, double divisor) { }
     }
     public static class TimeSpanBuilderExtensions
     {

--- a/Tests/aweXpect.Chronology.Tests/TimeSpanBuilderTests.cs
+++ b/Tests/aweXpect.Chronology.Tests/TimeSpanBuilderTests.cs
@@ -25,10 +25,32 @@ public sealed class TimeSpanBuilderTests
 	}
 
 	[Fact]
+	public async Task MultiplyOperator_ShouldAddTimeSpan()
+	{
+		TimeSpanBuilder expected = 6.Hours();
+		TimeSpanBuilder builder = new(3.Hours());
+
+		TimeSpan result = builder * 2;
+
+		await That(result).IsEqualTo(expected);
+	}
+
+	[Fact]
+	public async Task DivisionOperator_ShouldAddTimeSpan()
+	{
+		TimeSpanBuilder expected = 2.Hours();
+		TimeSpanBuilder builder = new(3.Hours());
+
+		TimeSpan result = builder / 1.5;
+
+		await That(result).IsEqualTo(expected);
+	}
+
+	[Fact]
 	public async Task UnaryMinusOperator_ShouldReturnNegatedValue()
 	{
 		TimeSpan expected = TimeSpan.FromHours(-1);
-		
+
 		TimeSpan result = -1.Hours();
 
 		await That(result).IsEqualTo(expected);


### PR DESCRIPTION
You can now apply a multiplication or divison to a `TimeSpanBuilder` and it will create a new `TimeSpanBuilder` whose underlying `TimeSpan` is multiplied or divided by accordingly.