### PR TITLE
fix: use dotnet nuget to push packages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -155,6 +155,8 @@ jobs:
                 with:
                     name: Packages
                     path: Artifacts/Packages
+            -   name: Setup .NET SDKs
+                uses: actions/setup-dotnet@v4
             -   name: Publish
                 run: |
                     echo "Found the following packages to push:"
@@ -165,7 +167,7 @@ jobs:
                     done
                     for entry in Artifacts/Packages/*.nupkg
                     do
-                      nuget push $entry -Source 'https://api.nuget.org/v3/index.json' -ApiKey ${{secrets.NUGET_API_KEY}} -SkipDuplicate
+                      dotnet nuget push $entry --source https://api.nuget.org/v3/index.json --api-key "${{secrets.NUGET_API_KEY}}" --skip-duplicate
                     done
             -   name: Check pre-release
                 id: check-pre-release

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -36,6 +36,7 @@ partial class Build
 
 			DotNetToolInstall(_ => _
 				.SetPackageName("dotnet-stryker")
+				.SetVersion("4.7.0")
 				.SetToolInstallationPath(toolPath));
 
 			Dictionary<Project, Project[]> projects = new()


### PR DESCRIPTION
This PR modernizes the NuGet package publishing process by replacing the legacy `nuget.exe` tool with the built-in `dotnet nuget` command. This change follows best practices recommended in [Meziantou's blog]((https://www.meziantou.net/publishing-a-nuget-package-following-best-practices-using-github.htm)) for more reliable and streamlined package publishing.

**Key changes:**
- Replaces `nuget push` with `dotnet nuget push` command using updated parameter syntax
- Adds .NET SDK setup to ensure `dotnet` command availability
- Updates dotnet-stryker tool version to 4.7.0