### PR TITLE
chore: update repository references to Testably organization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,7 +7,7 @@ All code should be covered by unit tests and comply with the coding guideline in
 
 ### Technical expectations
 As a framework for supporting unit testing, this project has a high standard for testing itself.  
-In order to support this, static code analysis is performed using [SonarCloud](https://sonarcloud.io/project/overview?id=aweXpect_aweXpect.Chronology) with quality gate requiring to
+In order to support this, static code analysis is performed using [SonarCloud](https://sonarcloud.io/project/overview?id=Testably_aweXpect.Chronology) with quality gate requiring to
 - solve all issues reported by SonarCloud
 - have a code coverage of > 90%
 

--- a/Pipeline/Build.Benchmarks.cs
+++ b/Pipeline/Build.Benchmarks.cs
@@ -54,7 +54,7 @@ partial class Build
 				Credentials tokenAuth = new(GithubToken);
 				gitHubClient.Credentials = tokenAuth;
 				IReadOnlyList<IssueComment> comments =
-					await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "aweXpect.Chronology", prId.Value);
+					await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "aweXpect.Chronology", prId.Value);
 				long? commentId = null;
 				Log.Information($"Found {comments.Count} comments");
 				foreach (IssueComment comment in comments)
@@ -69,12 +69,12 @@ partial class Build
 				if (commentId == null)
 				{
 					Log.Information($"Create comment:\n{body}");
-					await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Chronology", prId.Value, body);
+					await gitHubClient.Issue.Comment.Create("Testably", "aweXpect.Chronology", prId.Value, body);
 				}
 				else
 				{
 					Log.Information($"Update comment:\n{body}");
-					await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Chronology", commentId.Value, body);
+					await gitHubClient.Issue.Comment.Update("Testably", "aweXpect.Chronology", commentId.Value, body);
 				}
 			}
 		});

--- a/Pipeline/Build.CodeAnalysis.cs
+++ b/Pipeline/Build.CodeAnalysis.cs
@@ -16,8 +16,8 @@ partial class Build
 		.Executes(() =>
 		{
 			SonarScannerTasks.SonarScannerBegin(s => s
-				.SetOrganization("awexpect")
-				.SetProjectKey("aweXpect_aweXpect.Chronology")
+				.SetOrganization("testably")
+				.SetProjectKey("Testably_aweXpect.Chronology")
 				.AddVSTestReports(TestResultsDirectory / "*.trx")
 				.AddOpenCoverPaths(TestResultsDirectory / "reports" / "OpenCover.xml")
 				.SetPullRequestOrBranchName(GitHubActions, GitVersion)

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -58,7 +58,7 @@ partial class Build
 				                      {
 				                      	"stryker-config": {
 				                      		"project-info": {
-				                      			"name": "github.com/aweXpect/aweXpect.Chronology",
+				                      			"name": "github.com/Testably/aweXpect.Chronology",
 				                      			"module": "{{project.Key.Name}}",
 				                      			"version": "{{branchName}}"
 				                      		},
@@ -115,7 +115,7 @@ partial class Build
 
 			string body = "## :alien: Mutation Results"
 			              + Environment.NewLine
-			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Chronology%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Chronology/pull/{prId}/merge)"
+			              + $"[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Chronology%2Fpull/{prId}/merge)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Chronology/pull/{prId}/merge)"
 			              + Environment.NewLine
 			              + MutationCommentBody;
 
@@ -125,7 +125,7 @@ partial class Build
 				Credentials tokenAuth = new(GithubToken);
 				gitHubClient.Credentials = tokenAuth;
 				IReadOnlyList<IssueComment> comments =
-					await gitHubClient.Issue.Comment.GetAllForIssue("aweXpect", "aweXpect.Chronology", prId.Value);
+					await gitHubClient.Issue.Comment.GetAllForIssue("Testably", "aweXpect.Chronology", prId.Value);
 				long? commentId = null;
 				Log.Information($"Found {comments.Count} comments");
 				foreach (IssueComment comment in comments)
@@ -140,12 +140,12 @@ partial class Build
 				if (commentId == null)
 				{
 					Log.Information($"Create comment:\n{body}");
-					await gitHubClient.Issue.Comment.Create("aweXpect", "aweXpect.Chronology", prId.Value, body);
+					await gitHubClient.Issue.Comment.Create("Testably", "aweXpect.Chronology", prId.Value, body);
 				}
 				else
 				{
 					Log.Information($"Update comment:\n{body}");
-					await gitHubClient.Issue.Comment.Update("aweXpect", "aweXpect.Chronology", commentId.Value, body);
+					await gitHubClient.Issue.Comment.Update("Testably", "aweXpect.Chronology", commentId.Value, body);
 				}
 			}
 		});

--- a/Pipeline/Build.Pack.cs
+++ b/Pipeline/Build.Pack.cs
@@ -29,10 +29,10 @@ partial class Build
 			string[] lines = File.ReadAllLines(Solution.Directory / "README.md");
 			sb.AppendLine(lines.First());
 			sb.AppendLine(
-				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/aweXpect/aweXpect.Chronology/releases/tag/v{version})");
+				$"[![Changelog](https://img.shields.io/badge/Changelog-v{version}-blue)](https://github.com/Testably/aweXpect.Chronology/releases/tag/v{version})");
 			foreach (string line in lines.Skip(1))
 			{
-				if (line.StartsWith("[![Build](https://github.com/aweXpect/aweXpect.Chronology/actions/workflows/build.yml") ||
+				if (line.StartsWith("[![Build](https://github.com/Testably/aweXpect.Chronology/actions/workflows/build.yml") ||
 				    line.StartsWith("[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure"))
 				{
 					continue;

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # aweXpect.Chronology
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Chronology)](https://www.nuget.org/packages/aweXpect.Chronology) 
-[![Build](https://github.com/aweXpect/aweXpect.Chronology/actions/workflows/build.yml/badge.svg)](https://github.com/aweXpect/aweXpect.Chronology/actions/workflows/build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Chronology&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Chronology)
-[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=aweXpect_aweXpect.Chronology&metric=coverage)](https://sonarcloud.io/summary/new_code?id=aweXpect_aweXpect.Chronology)
-[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FaweXpect%2FaweXpect.Chronology%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/aweXpect/aweXpect.Chronology/main)
+[![Build](https://github.com/Testably/aweXpect.Chronology/actions/workflows/build.yml/badge.svg)](https://github.com/Testably/aweXpect.Chronology/actions/workflows/build.yml)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Chronology&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Chronology)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=Testably_aweXpect.Chronology&metric=coverage)](https://sonarcloud.io/summary/new_code?id=Testably_aweXpect.Chronology)
+[![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTestably%2FaweXpect.Chronology%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/Testably/aweXpect.Chronology/main)
 
 Extension methods for creating chronology objects like `TimeSpan` or `DateTime` that read more natural.
 

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -4,10 +4,10 @@
 			Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')"/>
 
 	<PropertyGroup>
-		<Authors>aweXpect</Authors>
+		<Authors>Testably</Authors>
 		<Description>Extension methods for creating chronology objects like `TimeSpan` or `DateTime` that read more natural.</Description>
 		<Copyright>Copyright (c) 2024 - $([System.DateTime]::Now.ToString('yyyy')) Valentin Breuß</Copyright>
-		<RepositoryUrl>https://github.com/aweXpect/aweXpect.Chronology.git</RepositoryUrl>
+		<RepositoryUrl>https://github.com/Testably/aweXpect.Chronology.git</RepositoryUrl>
 		<RepositoryType>git</RepositoryType>
 		<PackageLicenseExpression>MIT</PackageLicenseExpression>
 		<PackageIcon>Docs/logo_256x256.png</PackageIcon>

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net8.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Chronology.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Chronology.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v8.0", FrameworkDisplayName=".NET 8.0")]
 namespace aweXpect.Chronology
 {

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_netstandard2.0.txt
@@ -1,4 +1,4 @@
-[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/aweXpect/aweXpect.Chronology.git")]
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Chronology.git")]
 [assembly: System.Runtime.Versioning.TargetFramework(".NETStandard,Version=v2.0", FrameworkDisplayName=".NET Standard 2.0")]
 namespace aweXpect.Chronology
 {


### PR DESCRIPTION
Updates repository/organization references across build tooling, documentation, and API baseline expectations to reflect the move from the `aweXpect` GitHub/Sonar/Stryker organization to `Testably`.

**Changes:**
- Updated NuGet package metadata (`Authors`, `RepositoryUrl`) to point at `Testably`.
- Updated README badges/links (GitHub Actions, SonarCloud, Stryker) to the `Testably` org/project identifiers.
- Updated build pipeline scripts (Nuke targets) to generate links and post PR comments against `Testably/aweXpect.Chronology`, and adjusted SonarCloud organization/project key.