### PR TITLE
feat: support .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Run unit tests (windows)
                 if: matrix.os == 'windows-latest'
                 run: ./build.ps1 CodeCoverage
@@ -50,6 +51,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: API checks
                 run: ./build.sh ApiChecks
             -   name: Upload artifacts
@@ -76,6 +78,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Run mutation tests
                 run: ./build.sh MutationTests
     
@@ -95,6 +98,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Run sonarcloud analysis
                 run: ./build.sh CodeAnalysis
     
@@ -132,6 +136,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Pack nuget packages
                 run: ./build.sh Pack
             -   name: Upload packages

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Run unit tests (windows)
                 if: matrix.os == 'windows-latest'
                 run: ./build.ps1 CodeCoverage
@@ -50,6 +51,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: API checks
                 run: ./build.sh ApiChecks
             -   name: Upload artifacts
@@ -79,6 +81,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Run mutation tests
                 run: ./build.sh MutationTests
                 env:
@@ -102,6 +105,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Run benchmarks
                 run: ./build.sh Benchmarks
                 env:
@@ -124,6 +128,7 @@ jobs:
                 with:
                     dotnet-version: |
                         8.0.x
+                        10.0.x
             -   name: Run sonarcloud analysis
                 run: ./build.sh CodeAnalysis
     

--- a/Benchmarks/aweXpect..Chronology.Benchmarks/aweXpect.Chronology.Benchmarks.csproj
+++ b/Benchmarks/aweXpect..Chronology.Benchmarks/aweXpect.Chronology.Benchmarks.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateProgramFile>false</GenerateProgramFile>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,10 +9,10 @@
 		<PackageVersion Include="Nullable" Version="1.3.1" />
 	</ItemGroup>
 	<ItemGroup>
-		<PackageVersion Include="Nuke.Common" Version="9.0.4" />
-		<PackageVersion Include="Nuke.Components" Version="9.0.4" />
+		<PackageVersion Include="Nuke.Common" Version="10.1.0" />
+		<PackageVersion Include="Nuke.Components" Version="10.1.0" />
 		<PackageVersion Include="LibGit2Sharp" Version="0.31.0" />
-		<PackageVersion Include="SharpCompress" Version="0.39.0" />
+		<PackageVersion Include="SharpCompress" Version="0.47.4" />
 	</ItemGroup>
 	<ItemGroup>
 		<PackageVersion Include="Meziantou.Analyzer" Version="2.0.163" />

--- a/Pipeline/Build.CodeCoverage.cs
+++ b/Pipeline/Build.CodeCoverage.cs
@@ -15,7 +15,7 @@ partial class Build
 		{
 			ReportGenerator(s => s
 				.SetProcessToolPath(NuGetToolPathResolver.GetPackageExecutable("ReportGenerator", "ReportGenerator.dll",
-					framework: "net8.0"))
+					framework: "net10.0"))
 				.SetTargetDirectory(TestResultsDirectory / "reports")
 				.AddReports(TestResultsDirectory / "**/coverage.cobertura.xml")
 				.AddReportTypes(ReportTypes.OpenCover)

--- a/Pipeline/Build.MutationTests.cs
+++ b/Pipeline/Build.MutationTests.cs
@@ -36,7 +36,6 @@ partial class Build
 
 			DotNetToolInstall(_ => _
 				.SetPackageName("dotnet-stryker")
-				.SetVersion("4.7.0")
 				.SetToolInstallationPath(toolPath));
 
 			Dictionary<Project, Project[]> projects = new()
@@ -66,7 +65,7 @@ partial class Build
 				                      			{{string.Join(",\n\t\t\t", project.Value.Select(PathForJson))}}
 				                      		],
 				                      		"project": {{PathForJson(project.Key)}},
-				                      		"target-framework": "net8.0",
+				                      		"target-framework": "net10.0",
 				                      		"since": {
 				                      			"target": "main",
 				                      			"enabled": {{(GitVersion.BranchName != "main").ToString().ToLowerInvariant()}},

--- a/Pipeline/Build.cs
+++ b/Pipeline/Build.cs
@@ -19,7 +19,7 @@ partial class Build : NukeBuild
 
 	[Parameter("Github Token")] readonly string GithubToken;
 
-	[Required] [GitVersion(Framework = "net8.0", NoCache = true, NoFetch = true)] readonly GitVersion GitVersion;
+	[Required] [GitVersion(Framework = "net10.0", NoCache = true, NoFetch = true)] readonly GitVersion GitVersion;
 
 	[Solution(GenerateProjects = true)] readonly Solution Solution;
 

--- a/Pipeline/Build.csproj
+++ b/Pipeline/Build.csproj
@@ -2,7 +2,7 @@
 
 	<PropertyGroup>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
+		<TargetFramework>net10.0</TargetFramework>
 		<NoWarn>CS0649;CS0169;CA1050;CA1822;CA2211;IDE1006</NoWarn>
 		<NukeRootDirectory>..</NukeRootDirectory>
 		<NukeScriptDirectory>..</NukeScriptDirectory>

--- a/Source/Directory.Build.props
+++ b/Source/Directory.Build.props
@@ -21,7 +21,7 @@
 	</PropertyGroup>
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;net8.0;net10.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Tests/Directory.Build.props
+++ b/Tests/Directory.Build.props
@@ -3,7 +3,7 @@
 	<Import Project="$(MSBuildThisFileDirectory)/../Directory.Build.props" Condition="Exists('$(MSBuildThisFileDirectory)/../Directory.Build.props')" />
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0;net48</TargetFrameworks>
+		<TargetFrameworks>net10.0;net8.0;net48</TargetFrameworks>
 	</PropertyGroup>
 
 	<PropertyGroup>

--- a/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net10.0.txt
+++ b/Tests/aweXpect.Chronology.Api.Tests/Expected/aweXpect.Chronology_net10.0.txt
@@ -1,0 +1,105 @@
+[assembly: System.Reflection.AssemblyMetadata("RepositoryUrl", "https://github.com/Testably/aweXpect.Chronology.git")]
+[assembly: System.Runtime.Versioning.TargetFramework(".NETCoreApp,Version=v10.0", FrameworkDisplayName=".NET 10.0")]
+namespace aweXpect.Chronology
+{
+    public readonly struct DateBuilder
+    {
+        public DateBuilder(System.DateTime value) { }
+        public static System.DateTime op_Implicit(aweXpect.Chronology.DateBuilder builder) { }
+        public static System.DateOnly op_Implicit(aweXpect.Chronology.DateBuilder builder) { }
+        public static aweXpect.Chronology.DateBuilder operator +(aweXpect.Chronology.DateBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.DateBuilder operator -(aweXpect.Chronology.DateBuilder builder, System.TimeSpan time) { }
+    }
+    public readonly struct DateTimeBuilder
+    {
+        public DateTimeBuilder(System.DateTime value) { }
+        public static System.DateTime op_Implicit(aweXpect.Chronology.DateTimeBuilder builder) { }
+        public static System.DateOnly op_Implicit(aweXpect.Chronology.DateTimeBuilder builder) { }
+        public static System.TimeOnly op_Implicit(aweXpect.Chronology.DateTimeBuilder builder) { }
+        public static aweXpect.Chronology.DateTimeBuilder operator +(aweXpect.Chronology.DateTimeBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.DateTimeBuilder operator -(aweXpect.Chronology.DateTimeBuilder builder, System.TimeSpan time) { }
+    }
+    public static class DateTimeExtensions
+    {
+        public static System.DateTime After(this System.TimeSpan timeDifference, System.DateTime dateTime) { }
+        public static aweXpect.Chronology.DateBuilder After(this System.TimeSpan timeDifference, aweXpect.Chronology.DateBuilder dateTime) { }
+        public static System.DateTime After(this aweXpect.Chronology.TimeSpanBuilder timeDifference, System.DateTime dateTime) { }
+        public static aweXpect.Chronology.DateBuilder After(this aweXpect.Chronology.TimeSpanBuilder timeDifference, aweXpect.Chronology.DateBuilder dateTime) { }
+        public static aweXpect.Chronology.DateBuilder April(this int day, int year) { }
+        public static System.DateTime AsLocal(this System.DateTime dateTime) { }
+        public static aweXpect.Chronology.DateTimeBuilder AsLocal(this aweXpect.Chronology.DateTimeBuilder dateTime) { }
+        public static System.DateTime AsUtc(this System.DateTime dateTime) { }
+        public static aweXpect.Chronology.DateTimeBuilder AsUtc(this aweXpect.Chronology.DateTimeBuilder dateTime) { }
+        public static System.DateTime At(this System.DateOnly date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateTime date, System.TimeSpan time) { }
+        public static aweXpect.Chronology.DateTimeBuilder At(this aweXpect.Chronology.DateBuilder date, System.TimeSpan time) { }
+        public static System.DateTime At(this System.DateOnly date, int hours, int minutes, int seconds = 0, int milliseconds = 0) { }
+        public static System.DateTime At(this System.DateTime date, int hours, int minutes, int seconds = 0, int milliseconds = 0) { }
+        public static aweXpect.Chronology.DateTimeBuilder At(this aweXpect.Chronology.DateBuilder date, int hours, int minutes, int seconds = 0, int milliseconds = 0) { }
+        public static aweXpect.Chronology.DateBuilder August(this int day, int year) { }
+        public static System.DateTime Before(this System.TimeSpan timeDifference, System.DateTime dateTime) { }
+        public static aweXpect.Chronology.DateBuilder Before(this System.TimeSpan timeDifference, aweXpect.Chronology.DateBuilder dateTime) { }
+        public static System.DateTime Before(this aweXpect.Chronology.TimeSpanBuilder timeDifference, System.DateTime dateTime) { }
+        public static aweXpect.Chronology.DateBuilder Before(this aweXpect.Chronology.TimeSpanBuilder timeDifference, aweXpect.Chronology.DateBuilder dateTime) { }
+        public static aweXpect.Chronology.DateBuilder December(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder February(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder January(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder July(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder June(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder March(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder May(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder November(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder October(this int day, int year) { }
+        public static aweXpect.Chronology.DateBuilder September(this int day, int year) { }
+    }
+    public readonly struct DateTimeOffsetBuilder
+    {
+        public DateTimeOffsetBuilder(System.DateTimeOffset value) { }
+        public static System.DateTime op_Implicit(aweXpect.Chronology.DateTimeOffsetBuilder builder) { }
+        public static System.DateTimeOffset op_Implicit(aweXpect.Chronology.DateTimeOffsetBuilder builder) { }
+        public static System.DateOnly op_Implicit(aweXpect.Chronology.DateTimeOffsetBuilder builder) { }
+        public static System.TimeOnly op_Implicit(aweXpect.Chronology.DateTimeOffsetBuilder builder) { }
+        public static aweXpect.Chronology.DateTimeOffsetBuilder operator +(aweXpect.Chronology.DateTimeOffsetBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.DateTimeOffsetBuilder operator -(aweXpect.Chronology.DateTimeOffsetBuilder builder, System.TimeSpan time) { }
+    }
+    public static class DateTimeOffsetExtensions
+    {
+        public static aweXpect.Chronology.DateTimeOffsetBuilder WithOffset(this System.DateTime dateTime, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.DateTimeOffsetBuilder WithOffset(this aweXpect.Chronology.DateBuilder dateTime, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.DateTimeOffsetBuilder WithOffset(this aweXpect.Chronology.DateTimeBuilder dateTime, System.TimeSpan offset) { }
+    }
+    public readonly struct TimeSpanBuilder
+    {
+        public TimeSpanBuilder(System.TimeSpan value) { }
+        public static System.TimeSpan op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
+        public static System.TimeOnly op_Implicit(aweXpect.Chronology.TimeSpanBuilder builder) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator *(aweXpect.Chronology.TimeSpanBuilder builder, double multiplier) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator +(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder instance) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator -(aweXpect.Chronology.TimeSpanBuilder builder, System.TimeSpan time) { }
+        public static aweXpect.Chronology.TimeSpanBuilder operator /(aweXpect.Chronology.TimeSpanBuilder builder, double divisor) { }
+    }
+    public static class TimeSpanBuilderExtensions
+    {
+        public static aweXpect.Chronology.TimeSpanBuilder Days(this double days) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Days(this int days) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Days(this double days, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Days(this int days, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Hours(this double hours) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Hours(this int hours) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Hours(this double hours, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Hours(this int hours, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Milliseconds(this double milliseconds) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Milliseconds(this int milliseconds) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Milliseconds(this double milliseconds, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Milliseconds(this int milliseconds, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Minutes(this double minutes) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Minutes(this int minutes) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Minutes(this double minutes, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Minutes(this int minutes, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Seconds(this double seconds) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Seconds(this int seconds) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Seconds(this double seconds, System.TimeSpan offset) { }
+        public static aweXpect.Chronology.TimeSpanBuilder Seconds(this int seconds, System.TimeSpan offset) { }
+    }
+}

--- a/Tests/aweXpect.Chronology.Api.Tests/aweXpect.Chronology.Api.Tests.csproj
+++ b/Tests/aweXpect.Chronology.Api.Tests/aweXpect.Chronology.Api.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
-		<TargetFrameworks>net8.0</TargetFrameworks>
+		<TargetFrameworks>net10.0</TargetFrameworks>
 	</PropertyGroup>
 
 	<ItemGroup>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
 	"sdk": {
-		"version": "8.0.403",
+		"version": "10.0.201",
 		"rollForward": "latestMinor"
 	}
 }


### PR DESCRIPTION
This pull request upgrades the project to use .NET 10.0 across all main components, including build scripts, benchmarks, and tests. The changes ensure that the codebase, build pipelines, and test projects are aligned with the latest .NET SDK and target frameworks.

**.NET 10.0 Upgrade:**

* Updated `global.json` to require .NET SDK version 10.0.201 instead of 8.0.403.
* Changed all relevant `.csproj` files and build properties to target `net10.0` or include it as a supported framework, including in `Benchmarks/aweXpect.Chronology.Benchmarks.csproj`, `Pipeline/Build.csproj`, `Source/Directory.Build.props`, `Tests/Directory.Build.props`, and `Tests/aweXpect.Chronology.Api.Tests/aweXpect.Chronology.Api.Tests.csproj`.

**Build and Pipeline Updates:**

* Updated the `GitVersion` attribute and all build scripts to use the `net10.0` framework, including mutation testing and code coverage tools.