### PR TITLE
docs: add Docs/pages/00-index.md placeholder for Testably.Site inlining

### DIFF
--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -2,6 +2,4 @@
 
 [![Nuget](https://img.shields.io/nuget/v/aweXpect.Chronology)](https://www.nuget.org/packages/aweXpect.Chronology)
 
-[aweXpect.Chronology](https://github.com/Testably/aweXpect.Chronology) provides extension methods for creating `TimeSpan` and `DateTime` values that read more naturally.
-
 {README}

--- a/Docs/pages/00-index.md
+++ b/Docs/pages/00-index.md
@@ -1,0 +1,7 @@
+# aweXpect.Chronology
+
+[![Nuget](https://img.shields.io/nuget/v/aweXpect.Chronology)](https://www.nuget.org/packages/aweXpect.Chronology)
+
+[aweXpect.Chronology](https://github.com/Testably/aweXpect.Chronology) provides extension methods for creating `TimeSpan` and `DateTime` values that read more naturally.
+
+{README}


### PR DESCRIPTION
Adds an initial documentation landing page under `Docs/pages` intended to serve as the index entry for site generation that inlines the repository README.