### PR TITLE
fix: work around Rider slnx parser crash on Pipeline/Build.csproj

### DIFF
--- a/aweXpect.Chronology.slnx
+++ b/aweXpect.Chronology.slnx
@@ -4,8 +4,6 @@
   </Folder>
   <Folder Name="/Pipeline/">
     <Project Path="Pipeline/Build.csproj">
-      <BuildType Project="?" />
-      <Platform Project="?" />
       <Build Project="false" />
     </Project>
   </Folder>


### PR DESCRIPTION
Rider 2025.3 throws a NullReferenceException while parsing the Project="?" mappings on <BuildType> and <Platform>, silently aborting the solution open (no panels, no branch info, no error popup). dotnet build is unaffected.

<Build Project="false" /> alone excludes Pipeline/Build.csproj from solution build, so the two extra mappings were redundant.