### PR TITLE
ci: trigger Testably.Site rebuild after main build

### DIFF
--- a/.github/workflows/notify-docs-site.yml
+++ b/.github/workflows/notify-docs-site.yml
@@ -1,0 +1,22 @@
+name: Notify Docs Site
+
+on:
+    workflow_run:
+        workflows: [ "Build" ]
+        types: [ completed ]
+        branches: [ main ]
+    workflow_dispatch:
+
+jobs:
+    dispatch:
+        if: (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/main') || (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+        name: Trigger Site rebuild
+        runs-on: ubuntu-latest
+        steps:
+            -   name: Dispatch extension-documentation-updated-event to Testably/Testably.Site
+                uses: peter-evans/repository-dispatch@v3
+                with:
+                    token: ${{ secrets.SITE_DISPATCH_TOKEN }}
+                    repository: Testably/Testably.Site
+                    event-type: extension-documentation-updated-event
+                    client-payload: '{"source": "${{ github.repository }}", "sha": "${{ github.event.workflow_run.head_sha || github.sha }}"}'


### PR DESCRIPTION
After moving the repository to the Testably organization, documentation is centralized in Testably/Testably.Site. This workflow dispatches an `extension-documentation-updated-event` to Testably.Site whenever the Build workflow completes successfully on main, so the docs site picks up the change.